### PR TITLE
Refactoring Test Administration Methods

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -61,7 +61,7 @@ class Facility
   def administer_road_test(registrant)
     return false if !@services.include?('Road Test')
 
-    if registrant.license_data[:written]
+    if registrant.passed_written_test?
       status = true
       registrant.license_data[:license] = true
     else
@@ -73,7 +73,7 @@ class Facility
   def renew_drivers_license(registrant)
     return false if !@services.include?('Renew License')
 
-    if registrant.license_data[:written] && registrant.license_data[:license]
+    if registrant.passed_written_test? && registrant.passed_road_test?
       status = true
       registrant.license_data[:renewed] = true
     else

--- a/lib/registrant.rb
+++ b/lib/registrant.rb
@@ -21,4 +21,12 @@ class Registrant
   def earn_permit
     @permit = true
   end
+
+  def passed_written_test?
+    @license_data[:written]
+  end
+
+  def passed_road_test?
+    @license_data[:license]
+  end
 end

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe Registrant do
       expect(registrant_2.permit?).to be true
     end
   end
+
+  describe '#passed_written_test?' do
+    it 'returns true if the registrant has passed the written test' do
+      registrant_1 = Registrant.new('Person 1', 18)
+      registrant_2 = Registrant.new('Person 2', 18)
+      registrant_2.license_data[:written] = true
+
+      expect(registrant_1.passed_written_test?).to be false
+      expect(registrant_2.passed_written_test?).to be true
+    end
+  end
+
+  describe '#passed_road_test?' do
+    it 'returns true if the registrant has passed the road test' do
+      registrant_1 = Registrant.new('Person 1', 18)
+      registrant_2 = Registrant.new('Person 2', 18)
+      registrant_2.license_data[:written] = true
+      registrant_2.license_data[:license] = true
+
+      expect(registrant_1.passed_road_test?).to be false
+      expect(registrant_2.passed_road_test?).to be true
+    end
+  end
 end


### PR DESCRIPTION
This PR includes a refactoring of the administer_written_test and administer_road_test methods in the Facility class to use helper methods called from the Registrant class, which check to see if a registrant has passed their written or road tests, respectively. 

This follows the format of the '.permit?' method in the Registrant class.

Tests were also added for both helper methods.